### PR TITLE
Fix runClassifyTests failure print statement 

### DIFF
--- a/Tick2q/tick2.fs
+++ b/Tick2q/tick2.fs
@@ -116,6 +116,11 @@ module TestClassify =
         "BEng", 35.0, Ok "Fail"        
     ]
 
+    let printResult res = 
+        match res with 
+            | Ok s -> sprintf "Ok: %s" s
+            | Error s -> sprintf "Error: %s" s
+
     let runClassifyTests unitTests classify testName =
         unitTests
         |> List.map (fun (data as (course,mark,_)) -> classify course mark, data)
@@ -125,8 +130,8 @@ module TestClassify =
             | fails -> 
                 fails 
                 |> List.iter (fun (actual, (course,mark,className)) 
-                                -> printfn $"Test Failed: {course}, {mark}, expected className={className}, \
-                                          actual className={actual}")
+                                -> printfn $"Test Failed: {course}, {mark}, expected className={printResult className}, \
+                                          actual className={printResult actual}")
 
 
 //-------------------------------------------------------------------------------------------//

--- a/Tick2q/tick2.fsproj
+++ b/Tick2q/tick2.fsproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Tick2.fs" />
+    <Compile Include="tick2.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduce a `printResult` function to print the string contained in the `Result` returned by `classify`. Previously, if a test failed the print statement would look something like this:
```
Test Failed: MEng, 75, expected className=Microsoft.FSharp.Core.FSharpResult`2[System.String,System.String], actual className=Microsoft.FSharp.Core.FSharpResult`2[System.String,System.String]
```
Instead of:
```
Test Failed: MEng, 75, expected className=Ok: First, actual className=Error: Course boundary doesn't exist
```